### PR TITLE
Add start/stop requests for Virtual Display

### DIFF
--- a/flipper.proto
+++ b/flipper.proto
@@ -70,8 +70,10 @@ message Main {
         .PB_App.LockStatusResponse app_lock_status_response = 18;
         .PB_Gui.StartScreenStreamRequest gui_start_screen_stream_request = 20;
         .PB_Gui.StopScreenStreamRequest gui_stop_screen_stream_request = 21;
-        .PB_Gui.ScreenStreamFrame gui_screen_stream_frame = 22;
+        .PB_Gui.ScreenFrame gui_screen_frame = 22;
         .PB_Gui.SendInputEventRequest gui_send_input_event_request = 23;
+        .PB_Gui.StartVirtualDisplayRequest gui_start_virtual_display_request = 26;
+        .PB_Gui.StopVirtualDisplayRequest gui_stop_virtual_display_request = 27;
     }
 }
 

--- a/flipper.proto
+++ b/flipper.proto
@@ -33,6 +33,10 @@ enum CommandStatus {
     /**< Application Errors */
     ERROR_APP_CANT_START = 16; /**< Can't start app - internal error */
     ERROR_APP_SYSTEM_LOCKED = 17; /**< Another app is running */
+
+    /**< Virtual Display Errors */
+    ERROR_VIRTUAL_DISPLAY_ALREADY_STARTED = 19; /**< Virtual Display session can't be started twice */
+    ERROR_VIRTUAL_DISPLAY_NOT_STARTED = 20; /**< Virtual Display session can't be stopped when it's not started */
 }
 
 /* There are Server commands (e.g. Storage_write), which have no body message

--- a/gui.options
+++ b/gui.options
@@ -1,2 +1,2 @@
-PB_Gui.ScreenStreamFrame.data                  type:FT_POINTER
-PB_Gui.ScreenStreamFrame.data                  max_size:1024
+PB_Gui.ScreenFrame.data                  type:FT_POINTER
+PB_Gui.ScreenFrame.data                  max_size:1024

--- a/gui.proto
+++ b/gui.proto
@@ -20,17 +20,23 @@ enum InputType {
     REPEAT = 4; /**< Repeat event, emmited with INPUT_REPEATE_PRESS period after InputTypeLong event */
 }
 
+message ScreenFrame {
+    bytes data = 1;
+}
+
 message StartScreenStreamRequest {
 }
 
 message StopScreenStreamRequest {
 }
 
-message ScreenStreamFrame {
-    bytes data = 1;
-}
-
 message SendInputEventRequest {
     InputKey key = 1;
     InputType type = 2;
+}
+
+message StartVirtualDisplayRequest {
+}
+
+message StopVirtualDisplayRequest {
 }


### PR DESCRIPTION
I've also renamed `ScreenStreamFrame` to `ScreenFrame` to make it sound more universal since it's going to be used in both `ScreenStream` and `VirtualDisplay` processes.