### PR TITLE
Add protobuf versioning

### DIFF
--- a/flipper.proto
+++ b/flipper.proto
@@ -66,6 +66,8 @@ message Main {
         .PB_System.GetDateTimeResponse system_get_datetime_response = 36;
         .PB_System.SetDateTimeRequest system_set_datetime_request = 37;
         .PB_System.PlayAudiovisualAlertRequest system_play_audiovisual_alert_request = 38;
+        .PB_System.ProtobufVersionRequest system_protobuf_version_request = 39;
+        .PB_System.ProtobufVersionResponse system_protobuf_version_response = 40;
         .PB_Storage.InfoRequest storage_info_request = 28;
         .PB_Storage.InfoResponse storage_info_response = 29;
         .PB_Storage.StatRequest storage_stat_request = 24;

--- a/system.proto
+++ b/system.proto
@@ -55,3 +55,12 @@ message DateTime {
 
 message PlayAudiovisualAlertRequest {
 }
+
+message ProtobufVersionRequest {
+}
+
+message ProtobufVersionResponse {
+    uint32 major = 1;
+    uint32 minor = 2;
+}
+


### PR DESCRIPTION
Protobuf versioning is for handling RPC-clients communication.
Version can be acquired either via command ProtobufVersionRequest
or via device info request.
It's claimed to increase minor version when additional
functionality added, and increase major version when new changes
breaks backward compatibility.