### PR TITLE
[FL-3618] Support for button indices

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.21]
+### Added
+- Application AppButtonPressRequest now supports button indices in addition to names.
+
 ## [0.20]
 ### Added
 - Storage ListRequest message now has a file size filter.

--- a/application.proto
+++ b/application.proto
@@ -24,6 +24,7 @@ message AppLoadFileRequest {
 
 message AppButtonPressRequest {
     string args = 1;
+    int32 index = 2;
 }
 
 message AppButtonReleaseRequest {


### PR DESCRIPTION
Changes:
- Add index field to AppButtonPressRequest message (needed to uniquely address individual Infrared remote buttons which may have identical names)